### PR TITLE
Bugfix: Coverage collection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "tslib": "^2.4.0",
         "typescript": "^4.6.4",
         "vite": "^3.0.0",
+        "vite-tsconfig-paths": "^3.5.0",
         "vitest": "^0.21.1"
       }
     },
@@ -159,6 +160,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "node_modules/@cush/relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cush/relative/-/relative-1.0.0.tgz",
+      "integrity": "sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==",
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
@@ -1928,6 +1935,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-regex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/glob-regex/-/glob-regex-0.3.2.tgz",
+      "integrity": "sha512-m5blUd3/OqDTWwzBBtWBPrGlAzatRywHameHeekAZyZrskYouOGdNB8T/q6JucucvJXtOuyHIn0/Yia7iDasDw==",
+      "dev": true
+    },
     "node_modules/globals": {
       "version": "13.17.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
@@ -1962,6 +1975,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
@@ -2450,6 +2469,18 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -3003,6 +3034,24 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recrawl-sync": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recrawl-sync/-/recrawl-sync-2.2.2.tgz",
+      "integrity": "sha512-E2sI4F25Fu2nrfV+KsnC7/qfk/spQIYXlonfQoS4rwxeNK5BjxnLPbWiRXHVXPwYBOTWtPX5765kTm/zJiL+LQ==",
+      "dev": true,
+      "dependencies": {
+        "@cush/relative": "^1.0.0",
+        "glob-regex": "^0.3.0",
+        "slash": "^3.0.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/recrawl-sync/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3323,6 +3372,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -3580,6 +3638,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz",
+      "integrity": "sha512-AHx4Euop/dXFC+Vx589alFba8QItjF+8hf8LtmuiCwHyI4rHXQtOOENaM8kvYf5fR0dRChy3wzWIZ9WbB7FWow==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -3730,6 +3802,21 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-3.5.0.tgz",
+      "integrity": "sha512-NKIubr7gXgh/3uniQaOytSg+aKWPrjquP6anAy+zCWEn6h9fB8z2/qdlfQrTgZWaXJ2pHVlllrSdRZltHn9P4g==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "recrawl-sync": "^2.0.3",
+        "tsconfig-paths": "^4.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">2.0.0-0"
       }
     },
     "node_modules/vitest": {
@@ -4092,6 +4179,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "@cush/relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cush/relative/-/relative-1.0.0.tgz",
+      "integrity": "sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -5415,6 +5508,12 @@
         "is-glob": "^4.0.3"
       }
     },
+    "glob-regex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/glob-regex/-/glob-regex-0.3.2.tgz",
+      "integrity": "sha512-m5blUd3/OqDTWwzBBtWBPrGlAzatRywHameHeekAZyZrskYouOGdNB8T/q6JucucvJXtOuyHIn0/Yia7iDasDw==",
+      "dev": true
+    },
     "globals": {
       "version": "13.17.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
@@ -5437,6 +5536,12 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.10",
@@ -5810,6 +5915,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
     },
     "kleur": {
@@ -6197,6 +6308,26 @@
         "picomatch": "^2.2.1"
       }
     },
+    "recrawl-sync": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recrawl-sync/-/recrawl-sync-2.2.2.tgz",
+      "integrity": "sha512-E2sI4F25Fu2nrfV+KsnC7/qfk/spQIYXlonfQoS4rwxeNK5BjxnLPbWiRXHVXPwYBOTWtPX5765kTm/zJiL+LQ==",
+      "dev": true,
+      "requires": {
+        "@cush/relative": "^1.0.0",
+        "glob-regex": "^0.3.0",
+        "slash": "^3.0.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6426,6 +6557,12 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true
+    },
     "strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -6580,6 +6717,17 @@
         "punycode": "^2.1.1"
       }
     },
+    "tsconfig-paths": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz",
+      "integrity": "sha512-AHx4Euop/dXFC+Vx589alFba8QItjF+8hf8LtmuiCwHyI4rHXQtOOENaM8kvYf5fR0dRChy3wzWIZ9WbB7FWow==",
+      "dev": true,
+      "requires": {
+        "json5": "^2.2.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -6673,6 +6821,18 @@
         "postcss": "^8.4.16",
         "resolve": "^1.22.1",
         "rollup": "^2.75.6"
+      }
+    },
+    "vite-tsconfig-paths": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-3.5.0.tgz",
+      "integrity": "sha512-NKIubr7gXgh/3uniQaOytSg+aKWPrjquP6anAy+zCWEn6h9fB8z2/qdlfQrTgZWaXJ2pHVlllrSdRZltHn9P4g==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "recrawl-sync": "^2.0.3",
+        "tsconfig-paths": "^4.0.0"
       }
     },
     "vitest": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "tslib": "^2.4.0",
     "typescript": "^4.6.4",
     "vite": "^3.0.0",
+    "vite-tsconfig-paths": "^3.5.0",
     "vitest": "^0.21.1"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
-import './app.css';
-import App from './App.svelte';
+import 'src/app.css';
+import App from 'src/App.svelte';
 
 const app = new App({
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/test/App.unit.test.ts
+++ b/test/App.unit.test.ts
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/svelte';
-import App from '../src/App.svelte';
+import App from 'src/App.svelte';
 
 describe('App ...', () => {
   it('should render Hello World', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,13 +2,15 @@
 import { defineConfig } from 'vite';
 import { configDefaults } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     svelte({
       hot: !process.env.VITEST
-    })
+    }),
+    tsconfigPaths()
   ],
   test: {
     setupFiles: ['test/setupTests.ts'],


### PR DESCRIPTION
Coverage did not yet work as `c8` could not read files due to absolute imports, which should now work can be used. Resolved the issue in vitest myself: https://github.com/vitest-dev/vitest/issues/1828